### PR TITLE
Configure number of threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(
 )
 
 SET(PARTICLE_SWARM_NUM_DIMENSIONS 1 CACHE STRING "Number of dimensions for the Particle Swarm Optimization algorithm")
-OPTION(USE_THREADS "Enable multithreading for the Particle Swarm Optimization algorithm" ON)
+SET(PARTICLE_SWARM_NUM_THREADS 1 CACHE STRING "Number of optimization threads to use")
 
 # Doxygen document generation
 find_package(Doxygen)
@@ -73,11 +73,12 @@ target_compile_definitions(
 	${PROJECT_NAME}
 	PUBLIC
 		"SWARM_DIMENSIONS=${PARTICLE_SWARM_NUM_DIMENSIONS}"
+	PRIVATE
+		"SWARM_THREADS=${PARTICLE_SWARM_NUM_THREADS}"
 )
 
-if (USE_THREADS)
+if (PARTICLE_SWARM_NUM_THREADS GREATER 1)
 	find_package(Threads REQUIRED)
-	target_compile_definitions(${PROJECT_NAME} PRIVATE USE_THREADS)
 	target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads)
 endif()
 

--- a/include/swarm.h
+++ b/include/swarm.h
@@ -10,7 +10,7 @@
 
 #include <stddef.h>
 
-#ifdef USE_THREADS
+#if (SWARM_THREADS > 1)
 #include <pthread.h>
 #include <semaphore.h>
 #endif
@@ -23,10 +23,6 @@
  */
 #ifndef SWARM_DIMENSIONS
 #error "SWARM_DIMENSIONS must be defined"
-#endif
-
-#ifdef USE_THREADS
-#define NUM_THREADS 16
 #endif
 
 /**

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#ifdef USE_THREADS
+#if (SWARM_THREADS > 1)
 
 typedef struct _ThreadInfo_
 {
@@ -65,7 +65,7 @@ void optimize_MultiThreaded(
 		const float                   c2,
 		const Swarm_ProgressReport    progress)
 {
-	pthread_t       threads[NUM_THREADS];
+	pthread_t       threads[SWARM_THREADS];
 	sem_t           startSemaphore;
 	sem_t           doneSemaphore;
 	pthread_mutex_t mutex;
@@ -84,7 +84,7 @@ void optimize_MultiThreaded(
 	pthread_mutex_init(info.Mutex, NULL);
 	sem_init(info.StartSemaphore, 0, 0);
 	sem_init(info.DoneSemaphore, 0, 0);
-	for (size_t i = 0; i < NUM_THREADS; i++) { pthread_create(&threads[i], NULL, optimize_Thread, &info); }
+	for (size_t i = 0; i < SWARM_THREADS; i++) { pthread_create(&threads[i], NULL, optimize_Thread, &info); }
 
 	for (size_t itt = 0; itt < maxIterations; itt++)
 	{
@@ -103,8 +103,8 @@ void optimize_MultiThreaded(
 
 	// Cleanup
 	info.Continue = false;
-	for (size_t i = 0; i < NUM_THREADS; i++) { sem_post(info.StartSemaphore); } // Unblock threads to exit
-	for (size_t i = 0; i < NUM_THREADS; i++) { pthread_join(threads[i], NULL); }
+	for (size_t i = 0; i < SWARM_THREADS; i++) { sem_post(info.StartSemaphore); } // Unblock threads to exit
+	for (size_t i = 0; i < SWARM_THREADS; i++) { pthread_join(threads[i], NULL); }
 	sem_destroy(info.DoneSemaphore);
 	sem_destroy(info.StartSemaphore);
 	pthread_mutex_destroy(info.Mutex);

--- a/src/optimize.h
+++ b/src/optimize.h
@@ -3,16 +3,7 @@
 
 #include "swarm.h"
 
-void optimize_SingleThread(
-		Swarm*                        swarm,
-		const Swarm_ObjectiveFunction evaluate,
-		const size_t                  maxIterations,
-		const float                   w,
-		const float                   c1,
-		const float                   c2,
-		const Swarm_ProgressReport    progress);
-
-#ifdef USE_THREADS
+#if (SWARM_THREADS > 1)
 void optimize_MultiThreaded(
 		Swarm*                        swarm,
 		const Swarm_ObjectiveFunction evaluate,
@@ -23,6 +14,15 @@ void optimize_MultiThreaded(
 		const Swarm_ProgressReport    progress);
 
 void* optimize_Thread(void* arg);
+#else
+void optimize_SingleThread(
+		Swarm*                        swarm,
+		const Swarm_ObjectiveFunction evaluate,
+		const size_t                  maxIterations,
+		const float                   w,
+		const float                   c1,
+		const float                   c2,
+		const Swarm_ProgressReport    progress);
 #endif
 
 #endif

--- a/src/swarm.c
+++ b/src/swarm.c
@@ -26,7 +26,7 @@ void Swarm_Optimize(
 		const float                   c2,
 		const Swarm_ProgressReport    progress)
 {
-#ifdef USE_THREADS
+#if (SWARM_THREADS > 1)
 	optimize_MultiThreaded(swarm, evaluate, maxIterations, w, c1, c2, progress);
 #else
 	optimize_SingleThread(swarm, evaluate, maxIterations, w, c1, c2, progress);


### PR DESCRIPTION
Added CMake variable to define number of threads to use for optimization. Defining a single thread (1) disables requirement for pthread library and uses the main thread for optimization.